### PR TITLE
Handle shifting PagerDuty IDs.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,7 @@ async function main() {
 			console.log(`Not making an issue. The issue for this shift should be created after ${shouldCreateIssueAfter.toISOString()}.`);
 			continue;
 		}
-		const matchingExistingIssues = existingIssues.filter(issue => issue.body?.includes(shift.annotation()));
+		const matchingExistingIssues = existingIssues.filter(issue => shift.alternativeAnnotations().some(annotation => issue.body?.includes(annotation)));
 		if (matchingExistingIssues.length > 0) {
 			console.log(`Not making an issue. One already exists with number #${matchingExistingIssues[0].number}.`);
 			continue;

--- a/src/pagerduty.ts
+++ b/src/pagerduty.ts
@@ -27,7 +27,16 @@ export class OnCallShift {
 	}
 
 	annotation() {
-		return `<!-- pagerduty-on-call-issue-action: ${this.id} -->`;
+		return `<!-- pagerduty-on-call-issue-action: ${this.email}-${this.start.format("YYYY-MM-DD")} -->`;
+	}
+
+	alternativeAnnotations() {
+		return [
+			this.annotation(),
+			`<!-- pagerduty-on-call-issue-action: ${this.email}-${this.start.clone().subtract(1, "day").format("YYYY-MM-DD")} -->`,
+			`<!-- pagerduty-on-call-issue-action: ${this.email}-${this.start.clone().add(1, "day").format("YYYY-MM-DD")} -->`,
+			`<!-- pagerduty-on-call-issue-action: ${this.id} -->`,
+		];
 	}
 }
 

--- a/tests/pagerduty.test.ts
+++ b/tests/pagerduty.test.ts
@@ -39,6 +39,22 @@ describe("test getOnCallShifts()", () => {
 		expect(shifts[0].start.toISOString()).toEqual("2021-02-16T16:00:00.000Z");
 		expect(shifts[0].end.toISOString()).toEqual("2021-02-22T16:00:00.000Z");
 	});
+
+	it("should return sensible annotations for shifts and allow them to move by up to a day", async () => {
+		sinon.stub(inputs, "minimumShiftLength").returns(moment.duration(24, "hours"));
+		sinon.stub(inputs, "pagerDutyICalendarURL").returns("file://./tests/fixtures/schedule-with-cover.ics");
+		const shifts = await pagerduty.getOnCallShifts();
+
+		expect(shifts.length).toBe(1);
+
+		expect(shifts[0].annotation()).toBe("<!-- pagerduty-on-call-issue-action: user1@example.com-2021-02-16 -->");
+		expect(shifts[0].alternativeAnnotations()).toEqual([
+			"<!-- pagerduty-on-call-issue-action: user1@example.com-2021-02-16 -->",
+			"<!-- pagerduty-on-call-issue-action: user1@example.com-2021-02-15 -->",
+			"<!-- pagerduty-on-call-issue-action: user1@example.com-2021-02-17 -->",
+			"<!-- pagerduty-on-call-issue-action: Q0DR9KA5FQMJ34 -->",
+		]);
+	});
 });
 
 afterEach(function () {


### PR DESCRIPTION
I thought PagerDuty IDs would be reasonably stable but it seems like they are not. Instead of the ID we can use the email and start date, but handle small changes in date of up to one day.